### PR TITLE
Allow very-org-config for PRs from forks

### DIFF
--- a/.github/workflows/verify-org-config.yaml
+++ b/.github/workflows/verify-org-config.yaml
@@ -1,16 +1,24 @@
+  
 name: Verify Org Config
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - master
 jobs:
   verify-org-config:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout master
         uses: actions/checkout@v2.3.1
         with:
           persist-credentials: false
+          
+      - name: Checkout PR branch
+        uses: actions/checkout@v2.3.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: pr
 
       - name: Peribolos dry-run
         env:
@@ -20,7 +28,7 @@ jobs:
           echo $GITHUB_TOKEN > /tmp/TOKEN
           docker run --rm \
             -v /tmp/TOKEN:/etc/github/token \
-            -v $(pwd)/config.yaml:/etc/config/config.yaml \
+            -v $(pwd)/pr/config.yaml:/etc/config/config.yaml \
             gcr.io/k8s-prow/peribolos:$PERIBOLOS_VERSION \
             --github-token-path /etc/github/token \
             --config-path /etc/config/config.yaml \


### PR DESCRIPTION
The `pull_request` event runs in the context of the PR branch and therefore doesn't have access to repository secrets because all the scripts could be compromised.

`pull_request_target` on the other hand runs in the context of the target branch (=master). We can still checkout the PR branch and get the `config.yaml` file from there (no security risk, because that file alone can't do any harm).
