### PR TITLE
Add team SIAM-SID

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -99,6 +99,7 @@ orgs:
     - mariusreusch
     - matal0
     - mbobzin
+    - MegaRusher
     - mfredenhagen
     - MicBag
     - mikevader

--- a/config.yaml
+++ b/config.yaml
@@ -316,6 +316,7 @@ orgs:
         - stefan-jungo
         - rolfstebler
         - matal0
+        - MegaRusher
         privacy: closed
         repos:
           CICD-pipeline: admin

--- a/config.yaml
+++ b/config.yaml
@@ -606,6 +606,18 @@ orgs:
               ui-library-next: write
               utils: write
               ws-itsec_owasp: write
+          BITS_SIAM-SID:
+            description: 'BITS: SIAM Service Integration and Design'
+            maintainers:
+            - Solaflex
+            - vangual
+            - matal0
+            members:
+            - Georges52
+            - MegaRusher
+            privacy: closed
+            repos:
+              oim-api: write
           this-or-that:
             description: Team for This-or-That
             maintainers:


### PR DESCRIPTION
## Config changes proposed in this pull request
- Adds a team for SIAM-SID
- Adds Manuel to the group of known accounts

## For new organization members

### I acknowledge that
- [ ] I have **read and understood the [Open Source Guidelines](https://baloise.github.io/open-source/docs/arc42/)**
- [ ] I agree to **act accordingly (with due dilligence) to our guidelines**
- [ ] I have **no open questions** regarding the topics covered (please delete the "open questions" section)

### Open questions
- Is the nested placement within the "Open Source" group correct? I mimic'ed the other comparable groups
