### PR TITLE
Add Manuel of SIAM-SID to team and base org

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -99,6 +99,7 @@ orgs:
     - mariusreusch
     - matal0
     - mbobzin
+    - MegaRusher
     - mfredenhagen
     - MicBag
     - mikevader
@@ -608,6 +609,7 @@ orgs:
             - matal0
             members:
             - Georges52
+            - MegaRusher
             privacy: closed
             repos:
               oim-api: write


### PR DESCRIPTION
## Config changes proposed in this pull request
- Add manu of the SIAM-SID to the org and team. 

## For new organization members

### I acknowledge that
- [ ] I have **read and understood the [Open Source Guidelines](https://baloise.github.io/open-source/docs/arc42/)**
- [ ] I agree to **act accordingly (with due dilligence) to our guidelines**
- [ ] I have **no open questions** regarding the topics covered (please delete the "open questions" section)

### Open questions
- 
- 
