### PR TITLE
Add codecamp external participants

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -38,6 +38,7 @@ orgs:
     - BenjaminMueller84
     - BerSteve
     - bhaskarchenchu
+    - bliemli
     - borisrudolf
     - bsolar17
     - christiansiegel
@@ -90,6 +91,7 @@ orgs:
     - lundak
     - lrommerskirchen
     - m4rc0z
+    - madchr1st
     - mmarinkov
     - manuel84
     - marcellobellini
@@ -111,6 +113,7 @@ orgs:
     - OlgaSchwarz
     - olivierglath
     - petramohler
+    - phil-pona
     - predrag-arsic
     - r3dDoX
     - raltho


### PR DESCRIPTION
## Config changes proposed in this pull request
- Add users phil-pona, madchr1st and myself (we are external codecamp participants, @mebagel can confirm)

## For new organization members

### All above-mentioned users agree that

- [x] I have **read and understood the [Open Source Guidelines](https://baloise.github.io/open-source/docs/arc42/)**
- [x] I agree to **act accordingly (with due dilligence) to our guidelines**
- [x] I have **no open questions** regarding the topics covered (please delete the "open questions" section)