### PR TITLE
restore constitency in admin users

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -180,6 +180,8 @@ orgs:
         - kullmanp 
         - Tiliavir
         - svene
+        - dweber019
+        - mikevader
         privacy: closed
         repos:
           org: admin


### PR DESCRIPTION
make org admins equal to the admin team

## Config changes proposed in this pull request
- 
- 

## For new organization members

### I acknowledge that
- [ ] I have **read and understood the [Open Source Guidelines](https://baloise.github.io/open-source/docs/arc42/)**
- [ ] I agree to **act accordingly (with due dilligence) to our guidelines**
- [ ] I have **no open questions** regarding the topics covered (please delete the "open questions" section)

### Open questions
- 
- 
